### PR TITLE
feat: add Google Analytics header

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -2,6 +2,15 @@
 <html lang="en">
 
     <head>
+        <!-- Global site tag (gtag.js) - Google Analytics -->
+        <script async src="https://www.googletagmanager.com/gtag/js?id=UA-169461300-1"></script>
+        <script>
+            window.dataLayer = window.dataLayer || [];
+            function gtag(){dataLayer.push(arguments);}
+            gtag('js', new Date());
+            gtag('config', 'UA-169461300-1');
+        </script>
+
         <meta charset="UTF-8">
         <meta content="width=device-width, initial-scale=1, shrink-to-fit=no" name="viewport">
         <link rel="shortcut icon" href="{{ site.url }}{{ site.baseurl }}/assets/images/logo-ae.jpeg" type="image/x-icon">


### PR DESCRIPTION
Now, pages are tracked into Google Analytics using the official
"aprendereconomia.unifal@gmail.com" account and "Aprender Economia"
project.

Signed-off-by: José Tobias <jose.tobias@outlook.com>